### PR TITLE
fix: default layout to "page" when frontmatter omits the key (closes #67)

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,25 +1,38 @@
 # cargo-audit configuration
 # Ignores for transitive advisories that cannot be fixed locally
 #
-# Last reviewed: 2026-04-17
-# Next review:   2026-07-17
+# Last reviewed: 2026-06-28
+# Next review:   2026-09-28
 
 [advisories]
 ignore = [
-    # Transitive via metadata-gen → serde_yml (unsound, unmaintained)
-    # No fix until metadata-gen migrates off serde_yml
+    # Transitive surfaces of the legacy YAML stack. metadata-gen 0.0.4 has
+    # already migrated to noyalib, but older versions of these crates can
+    # still appear in the resolved dep graph via unrelated transitives.
     "RUSTSEC-2025-0067",  # libyml - unsound
     "RUSTSEC-2025-0068",  # serde_yml - unsound
 
     # Transitive via syntect → yaml-rust (unmaintained)
     "RUSTSEC-2024-0320",  # yaml-rust
 
-    # Transitive unmaintained crates with no alternatives
+    # Transitive unmaintained crates with no actionable alternatives
     "RUSTSEC-2024-0436",  # paste - unmaintained
     "RUSTSEC-2025-0057",  # fxhash - unmaintained
     "RUSTSEC-2025-0119",  # number_prefix - unmaintained
     "RUSTSEC-2025-0141",  # bincode - unmaintained
 
-    # Transitive via vrd → rand 0.8 (unsound with custom logger)
+    # Soundness advisory on rand 0.8 ThreadRng custom-logger reseed path.
+    # We pin rand 0.8.6 (the patched version) in our direct graph (closed
+    # in v0.0.10). Some transitives still resolve to an older 0.8.x via
+    # their own minimum-version selectors; the path is not reachable from
+    # staticdatagen's public surface (no custom logger calls rand::rng()
+    # during reseed).
     "RUSTSEC-2026-0097",  # rand - unsound
+
+    # Deep transitive via defmt-macros → proc-macro-error2 (unmaintained
+    # 2026-06-07). Proc-macro helper crate, not reachable from any runtime
+    # path of staticdatagen. Re-evaluate when defmt-macros migrates to
+    # `manyhow` or `proc-macro2-diagnostics` (the upstream's recommended
+    # replacements per RUSTSEC-2026-0173).
+    "RUSTSEC-2026-0173",  # proc-macro-error2 - unmaintained
 ]

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,30 +8,52 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
-# Default permissions are read-only on pull_request from forks (and on
-# any repo that opts into the new restrictive default). The `rustsec/
-# audit-check` action invoked by the reusable rust-ci.yml workflow needs
-# `checks: write` to create its check-run annotation; without it the
-# audit step succeeds (0 vulnerabilities) but the job fails on
-# "Resource not accessible by integration". Granting it at the caller
-# is propagated into the reusable workflow.
-permissions:
-  contents: read
-  checks: write
-  pull-requests: read
-  security-events: write
-  actions: read
+# No caller-level `permissions:` block. A workflow-level block would
+# cap the ceiling for every reusable workflow we call, and `docs.yml`'s
+# `deploy` job requests `pages: write` + `id-token: write` (for GitHub
+# Pages OIDC). A restrictive ceiling here fails the workflow at
+# startup with "The nested job 'deploy' is requesting 'pages: write,
+# id-token: write', but is only allowed 'pages: none, id-token: none'".
+# Each reusable workflow declares its own job-level permissions, which
+# is the correct boundary.
 
 jobs:
   # ── Primary: stable, all checks, cross-platform ──────────────────
+  # `run-audit: false` because the reusable workflow's audit job only
+  # grants `contents: read`, leaving `rustsec/audit-check` unable to
+  # POST its check-run summary ("Resource not accessible by
+  # integration"). The local `audit` job below runs the same action
+  # with the `checks: write` permission it actually needs.
   ci:
     uses: sebastienrousseau/pipelines/.github/workflows/rust-ci.yml@main
     with:
       rust-version: 'stable'
+      run-audit: false
       run-coverage: true
       run-cross-platform: true
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  # ── Audit: run inline with `checks: write` (the upstream reusable
+  # workflow only grants `contents: read`, which makes the
+  # `rustsec/audit-check` action fail when it tries to POST a
+  # check-run summary). Reads `.cargo/audit.toml` for the ignore list.
+  audit:
+    name: Audit
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: read
+      checks: write
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+          show-progress: false
+      - uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
 
   # ── MSRV: minimum supported Rust version ─────────────────────────
   msrv:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,20 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+# Default permissions are read-only on pull_request from forks (and on
+# any repo that opts into the new restrictive default). The `rustsec/
+# audit-check` action invoked by the reusable rust-ci.yml workflow needs
+# `checks: write` to create its check-run annotation; without it the
+# audit step succeeds (0 vulnerabilities) but the job fails on
+# "Resource not accessible by integration". Granting it at the caller
+# is propagated into the reusable workflow.
+permissions:
+  contents: read
+  checks: write
+  pull-requests: read
+  security-events: write
+  actions: read
+
 jobs:
   # ── Primary: stable, all checks, cross-platform ──────────────────
   ci:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.0.10] — 2026-06-28
+
+### Fixed
+- **#67 — Empty `layout:` key crashed `render_page`.** Frontmatter missing or empty `layout:` now falls back to `"page"` instead of passing `""` to staticweaver (which aborted with `invalid template or partial name: ""`). Unblocks every page authored without a layout key, including the ≈ 1,137 of 2,371 affected files on multilingual Jekyll-style trees. (`src/compiler/service.rs`)
+- **#68 — `copy_auxiliary_files` aborted when `main.js` / `sw.js` were absent.** The copy is now best-effort: missing auxiliary files are logged at `debug` and skipped instead of failing the build with opaque `os error 2`. Sites that don't ship a service worker can build cleanly. (`src/utilities/write.rs`)
+- **#69 — `write_tags_html_to_file` aborted builds without a tags template.** Skips the substitution gracefully when `tags/index.html` is absent. (`src/generators/tags.rs`)
+- **#70 — `add()` skipped subdirectories.** Switched to `walkdir::WalkDir` so multilingual `_posts/<lang>/` trees and any nested locale layout are processed. Per-locale subdirs are preserved through `get_processed_file_name` via `with_extension("")` so output URLs keep their `fr/`, `bn/`, etc. prefixes. (`src/utilities/file.rs`, `src/utilities/write.rs`)
+- **#71 — Misleading "Successfully generated…" log fired before compile errors propagated.** The success line now fires *after* the final `fs::rename`, so log scrapers (`ssg`, CI tooling) can rely on it as a build-state signal. (`src/compiler/service.rs`)
+
+### Security
+- **GHSA-cq8v-f236-94qc / RUSTSEC-2026-0097** — Bumped `rand` to 0.8.6, resolving the Stacked-Borrows unsoundness in `ThreadRng` reachable through custom loggers that call `rand::rng()` while reseeding. Closes Dependabot alerts #1 and #2.
+
+### Changed
+- **Dependencies** — Bumped to current latest minors:
+  - `staticweaver` 0.0.2 → 0.0.3
+  - `rss-gen` 0.0.5 → 0.0.6
+  - `regex` 1.11 → 1.12
+  - `walkdir` 2 → 2.5
+  - `uuid` 1.11 → 1.23
+  - `idna` 1.0 → 1.1
+  - `rayon` 1.10 → 1.12
+  - `proptest` (dev) 1.6 → 1.11
+  - `tempfile` (dev) 3 → 3.27
+
 ## [0.0.9] — 2026-06-21
 
 ### Changed

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3671,6 +3671,7 @@ dependencies = [
  "url",
  "uuid",
  "version_check",
+ "walkdir",
  "xml-rs 1.0.0",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2799,7 +2799,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
 dependencies = [
  "phf_shared 0.11.3",
- "rand 0.8.5",
+ "rand 0.8.6",
 ]
 
 [[package]]
@@ -3100,9 +3100,9 @@ checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
-version = "0.8.5"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
 dependencies = [
  "rand_core 0.6.4",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,7 +120,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -131,14 +131,14 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
 name = "arraydeque"
@@ -741,6 +741,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-channel"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "82b8f8f868b36967f9606790d1903570de9ceaf870a7bf9fbbd3016d636a2cb2"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -966,7 +975,6 @@ version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
- "powerfmt",
  "serde_core",
 ]
 
@@ -1209,7 +1217,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1529,13 +1537,15 @@ dependencies = [
 
 [[package]]
 name = "http-handle"
-version = "0.0.4"
+version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "168bdf0482e99f2193ebe6df957fc0456f7f2c17c44146edc9326f8f5a48ac79"
+checksum = "3cf34d328daadca2f19e07da47d9485568162ab9f6514cd7304580871205e8d9"
 dependencies = [
+ "crossbeam-channel",
  "ctrlc",
  "euxis-commons",
  "log",
+ "memchr",
  "regex",
  "serde",
  "serde_json",
@@ -1881,9 +1891,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "mac"
@@ -2192,9 +2202,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.1"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-integer"
@@ -2977,9 +2987,9 @@ dependencies = [
 
 [[package]]
 name = "proptest"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec 0.8.0",
@@ -3016,9 +3026,9 @@ dependencies = [
 
 [[package]]
 name = "pulldown-cmark"
-version = "0.13.3"
+version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c3a14896dfa883796f1cb410461aef38810ea05f2b2c33c5aded3649095fdad"
+checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
  "bitflags",
  "getopts",
@@ -3053,15 +3063,6 @@ name = "quick-xml"
 version = "0.38.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
-dependencies = [
- "memchr",
-]
-
-[[package]]
-name = "quick-xml"
-version = "0.39.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd58c6a1fc307e1092aa0bb23d204ca4d1f021764142cd0424dccc84d2d5d106"
 dependencies = [
  "memchr",
 ]
@@ -3152,9 +3153,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
 dependencies = [
  "either",
  "rayon-core",
@@ -3252,7 +3253,7 @@ version = "0.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b80bc3f61d3a43d92302b7d7b1bbc2db17b3f83eeae69f5ab87730829166f592"
 dependencies = [
- "dtt 0.0.9",
+ "dtt 0.0.10",
  "euxis-commons",
  "log",
  "quick-xml 0.40.1",
@@ -3295,7 +3296,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3626,7 +3627,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -3656,7 +3657,7 @@ dependencies = [
  "metadata-gen",
  "proptest",
  "pulldown-cmark",
- "quick-xml 0.39.1",
+ "quick-xml 0.40.1",
  "rayon",
  "regex",
  "rss-gen",
@@ -3811,7 +3812,7 @@ dependencies = [
  "getrandom 0.4.1",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3898,12 +3899,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "85c17d80feb7334b40c484e45ed1a5273dfd8bfda537c3be2e74a06a6686f327"
 dependencies = [
  "deranged",
- "itoa",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -3913,15 +3913,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "9e1c906769ad99c88eaa54e728060edef082f8e358ff32030cb7c7d315e81109"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "dcef1a61bdb119096e153208ec5cbec23944ce8bca13be5c7f60c634f7403935"
 dependencies = [
  "num-conv",
  "time-core",
@@ -4177,9 +4177,9 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.0"
+version = "1.23.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ac8b6f42ead25368cf5b098aeb3dc8a1a2c05a3eee8a9a1a68c640edbfc79d9"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
 dependencies = [
  "getrandom 0.4.1",
  "js-sys",
@@ -4401,7 +4401,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,9 +86,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "824a212faf96e9acacdbd09febd34438f8f711fb84e09a8916013cd7815ca28d"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -101,15 +101,15 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "940b3a0ca603d1eade50a4846a2afffd5ef57a9feac2c0e2ec2e14f9ead76000"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "52ce7f38b242319f7cabaa6813055467063ecdc9d355bbb4ce0c68908cd8130e"
 dependencies = [
  "utf8parse",
 ]
@@ -120,7 +120,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -131,26 +131,20 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.102"
+version = "1.0.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+checksum = "2a4385e2e34eb35d6b3efe798b9eb88096925d87726c0798709bf56d9ed84af3"
 
 [[package]]
 name = "arraydeque"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d902e3d592a523def97af8f317b08ce16b7ab854c1985a0c671e6f15cebc236"
-
-[[package]]
-name = "askama_escape"
-version = "0.10.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "619743e34b5ba4e9703bba34deac3427c72507c7159f5fd030aea8cac0cfe341"
 
 [[package]]
 name = "async-trait"
@@ -160,14 +154,14 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "base64"
@@ -235,15 +229,21 @@ checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bitflags"
+version = "2.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4388bee8683e3d04af747c73422af53102d2bd24d9eadb6cbc100baef4b43f8"
 
 [[package]]
 name = "bitvec"
-version = "1.0.1"
+version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+checksum = "ddcec3d12c579d40898fe0a9a358a803c23e9c52ca3c425707f81c9436211837"
 dependencies = [
  "funty",
  "radium",
@@ -262,9 +262,9 @@ dependencies = [
 
 [[package]]
 name = "bon"
-version = "3.8.2"
+version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234655ec178edd82b891e262ea7cf71f6584bcd09eff94db786be23f1821825c"
+checksum = "a602c73c7b0148ec6d12af6fd5cc7a46e2eacc8878271a999abac56eed12f561"
 dependencies = [
  "bon-macros",
  "rustversion",
@@ -272,9 +272,9 @@ dependencies = [
 
 [[package]]
 name = "bon-macros"
-version = "3.8.2"
+version = "3.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89ec27229c38ed0eb3c0feee3d2c1d6a4379ae44f418a29a658890e062d8f365"
+checksum = "6dee98b0db6a962de883bf5d20362dee4d7ca0d12fe39a7c6c73c844e1cd7c1f"
 dependencies = [
  "darling 0.23.0",
  "ident_case",
@@ -282,7 +282,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -324,9 +324,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 
 [[package]]
 name = "caseless"
@@ -354,9 +354,9 @@ dependencies = [
 
 [[package]]
 name = "cc"
-version = "1.2.55"
+version = "1.2.65"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
+checksum = "e228eec9be7c17ccb640b59b36a5cd805ea2a564a4c5e162c2f659fea30d3b96"
 dependencies = [
  "find-msvc-tools",
  "shlex",
@@ -490,9 +490,9 @@ dependencies = [
 
 [[package]]
 name = "clap"
-version = "4.5.57"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6899ea499e3fb9305a65d5ebf6e3d2248c5fab291f300ad0a704fbe142eae31a"
+checksum = "1ddb117e43bbf7dacf0a4190fef4d345b9bad68dfc649cb349e7d17d28428e51"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -500,9 +500,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.57"
+version = "4.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b12c8b680195a62a8364d16b8447b01b6c2c8f9aaf68bee653be34d4245e238"
+checksum = "714a53001bf66416adb0e2ef5ac857140e7dc3a0c48fb28b2f10762fc4b5069f"
 dependencies = [
  "anstream",
  "anstyle",
@@ -513,21 +513,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "f2ce8604710f6733aa641a2b3731eaa1e8b3d9973d5e3565da11800813f997a9"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "0.7.7"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3e64b0cc0439b12df2fa678eae89a1c56a529fd067a9115f7827f1fffd22b32"
+checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
 name = "cobs"
@@ -540,15 +540,15 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
-version = "0.9.0"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb1325a1cece981e8a296ab8f0f9b63ae357bd0784a9faaf548cc7b480707a"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -615,7 +615,7 @@ dependencies = [
  "jetscii",
  "phf 0.13.1",
  "phf_codegen 0.13.1",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "shell-words",
  "smallvec",
  "syntect",
@@ -640,7 +640,7 @@ dependencies = [
  "jetscii",
  "phf 0.13.1",
  "phf_codegen 0.13.1",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "shell-words",
  "smallvec",
  "syntect",
@@ -848,7 +848,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13b588ba4ac1a99f7f2964d24b3d896ddc6bf847ee3855dbd4366f058cfcd331"
 dependencies = [
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -858,7 +858,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "10a2a99df6e410a8ff4245aa2006499ea662245f967cc7c0a38c83ef8eb44dbf"
 dependencies = [
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -903,7 +903,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -916,7 +916,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -927,7 +927,7 @@ checksum = "fc34b93ccb385b40dc71c6fceac4b2ad23662c7eeb248cf10d529b7e055b6ead"
 dependencies = [
  "darling_core 0.20.11",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -938,7 +938,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core 0.23.0",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -956,9 +956,9 @@ dependencies = [
 
 [[package]]
 name = "data-encoding"
-version = "2.10.0"
+version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
 
 [[package]]
 name = "data-url"
@@ -967,6 +967,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a30bfce702bcfa94e906ef82421f2c0e61c076ad76030c16ee5d2e9a32fe193"
 dependencies = [
  "matches",
+]
+
+[[package]]
+name = "defmt"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6e524506490a1953d237cb87b1cfc1e46f88c18f10a22dfe0f507dc6bfc7f7f"
+dependencies = [
+ "bitflags 1.3.2",
+ "defmt-macros",
+]
+
+[[package]]
+name = "defmt-macros"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0a27770e9c8f719a79d8b638281f4d828f77d8fd61e0bd94451b9b85e576a0b"
+dependencies = [
+ "defmt-parser",
+ "proc-macro-error2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "defmt-parser"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10d60334b3b2e7c9d91ef8150abfb6fa4c1c39ebbcf4a81c2e346aad939fee3e"
+dependencies = [
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -996,7 +1028,7 @@ dependencies = [
  "darling 0.20.11",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1006,7 +1038,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab63b0e2bf4d5928aff72e83a7dace85d7bba5fe12dcc3c5a572d78caffd3f3c"
 dependencies = [
  "derive_builder_core",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1017,7 +1049,7 @@ checksum = "6edb4b64a43d977b8e99788fe3a04d483834fba1215a7e02caa415b626497f7f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1038,7 +1070,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1053,7 +1085,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "block2",
  "libc",
  "objc2",
@@ -1061,13 +1093,13 @@ dependencies = [
 
 [[package]]
 name = "displaydoc"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1135,9 +1167,9 @@ checksum = "b04dc5a38e4f151a79d9f2451ae6037fb6eaf5cba34771f44781f80e508498e3"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "embedded-io"
@@ -1153,9 +1185,9 @@ checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
 
 [[package]]
 name = "emojis"
-version = "0.8.0"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50c1c1870b766fc398e5f0526498d09c94b6de15be5fd769a28bbc804fb1b05d"
+checksum = "0a4d5d50b0b58df5173d8ff1192b4d1422ceae5d981b30d4b6f8ed1d673a2bc4"
 dependencies = [
  "phf 0.13.1",
 ]
@@ -1183,9 +1215,9 @@ checksum = "b5320ae4c3782150d900b79807611a59a99fc9a1d61d686faafc24b93fc8d7ca"
 
 [[package]]
 name = "env_filter"
-version = "0.1.4"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bf3c259d255ca70051b30e2e95b5446cdb8949ac4cd22c0d7fd634d89f568e2"
+checksum = "900d271a03799a1ee8d1ca9b19893b48ca674a9284fefcfb85f05e74ed314217"
 dependencies = [
  "log",
  "regex",
@@ -1193,9 +1225,9 @@ dependencies = [
 
 [[package]]
 name = "env_logger"
-version = "0.11.8"
+version = "0.11.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13c863f0904021b108aa8b2f55046443e6b1ebde8fd4a15c399893aae4fa069f"
+checksum = "de671bd27a75a797dc9ae289ba1e77276e75e2026408aab65185384e2d5cd3f6"
 dependencies = [
  "anstream",
  "anstyle",
@@ -1217,7 +1249,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1242,9 +1274,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.3.0"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -1318,6 +1350,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-core"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-task"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "037711b3d59c33004d3856fbdc83b99d4ff37a24768fa1be9ce3538a1cde4393"
+
+[[package]]
+name = "futures-util"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
 name = "fxhash"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1355,22 +1411,20 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.4.1"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "139ef39800118c7683f2fd3c98c1b23c09ae076556b435f8e9064ae108aaeeec"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
- "wasip2",
- "wasip3",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -1429,6 +1483,12 @@ dependencies = [
  "allocator-api2",
  "foldhash 0.2.0",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
 
 [[package]]
 name = "hashlink"
@@ -1555,12 +1615,13 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "2984d1cd16c883d7935b9e07e44071dca8d917fd52ecc02c04d5fa0b5a3f191c"
 dependencies = [
  "displaydoc",
  "potential_utf",
+ "utf8_iter",
  "yoke",
  "zerofrom",
  "zerovec",
@@ -1568,9 +1629,9 @@ dependencies = [
 
 [[package]]
 name = "icu_locale_core"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "92219b62b3e2b4d88ac5119f8904c10f8f61bf7e95b640d25ba3075e6cac2c29"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -1581,9 +1642,9 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "c56e5ee99d6e3d33bd91c5d85458b6005a22140021cc324cea84dd0e72cff3b4"
 dependencies = [
  "icu_collections",
  "icu_normalizer_data",
@@ -1595,15 +1656,15 @@ dependencies = [
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "da3be0ae77ea334f4da67c12f149704f19f81d1adf7c51cf482943e84a2bad38"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "bee3b67d0ea5c2cca5003417989af8996f8604e34fb9ddf96208a033901e70de"
 dependencies = [
  "icu_collections",
  "icu_locale_core",
@@ -1615,15 +1676,15 @@ dependencies = [
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "8e2bbb201e0c04f7b4b3e14382af113e17ba4f63e2c9d2ee626b720cbce54a14"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "139c4cf31c8b5f33d7e199446eff9c1e02decfc2f0eec2c8d71f65befa45b421"
 dependencies = [
  "displaydoc",
  "icu_locale_core",
@@ -1633,12 +1694,6 @@ dependencies = [
  "zerotrie",
  "zerovec",
 ]
-
-[[package]]
-name = "id-arena"
-version = "2.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
 name = "ident_case"
@@ -1659,9 +1714,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -1669,12 +1724,12 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
  "serde",
  "serde_core",
 ]
@@ -1736,9 +1791,9 @@ dependencies = [
 
 [[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jetscii"
@@ -1748,10 +1803,11 @@ checksum = "47f142fe24a9c9944451e8349de0a56af5f3e7226dc46f3ed4d4ecc0b85af75e"
 
 [[package]]
 name = "jiff"
-version = "0.2.19"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89a5b5e10d5a9ad6e5d1f4bd58225f655d6fe9767575a5e8ac5a6fe64e04495"
+checksum = "34f877a98676d2fb664698d74cc6a51ce6c484ce8c770f05d0108ec9090aeb46"
 dependencies = [
+ "defmt",
  "jiff-static",
  "log",
  "portable-atomic",
@@ -1761,22 +1817,23 @@ dependencies = [
 
 [[package]]
 name = "jiff-static"
-version = "0.2.19"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff7a39c8862fc1369215ccf0a8f12dd4598c7f6484704359f0351bd617034dbf"
+checksum = "0666b5ab5ecaca213fc2a85b8c0083d9004e84ee2d5f9a7e0017aaf50986f25f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "53b44bfcdb3f8d5837a46dae1ca9660a837176eee74a28b229bc626816589102"
 dependencies = [
- "once_cell",
+ "cfg-if",
+ "futures-util",
  "wasm-bindgen",
 ]
 
@@ -1811,25 +1868,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
-name = "leb128fmt"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
-
-[[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "lightningcss"
-version = "1.0.0-alpha.70"
+version = "1.0.0-alpha.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9efb6a77b2389e62735b0b8157be9cc10a159eb4d1c3b864e99db9f297ada1b0"
+checksum = "cb6314c2f0590ac93c86099b98bb7ba8abcf759bfd89604ffca906472bb54937"
 dependencies = [
  "ahash 0.8.12",
- "bitflags",
+ "bitflags 2.13.0",
  "const-str",
  "cssparser 0.33.0",
  "cssparser-color",
@@ -1876,9 +1927,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
 
 [[package]]
 name = "lock_api"
@@ -1951,7 +2002,7 @@ checksum = "88a9689d8d44bf9964484516275f5cd4c9b59457a6940c1d5d0ecbb94510a36b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -1962,7 +2013,7 @@ checksum = "ac84fd3f360fcc43dc5f5d186f02a94192761a080e8bc58621ad4d12296a58cf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2017,9 +2068,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "metadata-gen"
@@ -2131,9 +2182,9 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.2.0"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
+checksum = "02bd0af71c67b473010cbbc60715ee815645a4dc942899111f494b4b737d6fda"
 dependencies = [
  "libc",
  "wasi",
@@ -2148,11 +2199,11 @@ checksum = "650eef8c711430f1a879fdd01d4745a7deea475becfb90269c06775983bbf086"
 
 [[package]]
 name = "nix"
-version = "0.31.2"
+version = "0.31.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d6d0705320c1e6ba1d912b5e37cf18071b6c2e9b7fa8215a1e8a7651966f5d3"
+checksum = "cf20d2fde8ff38632c426f1165ed7436270b44f199fc55284c38276f9db47c3d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "cfg-if",
  "cfg_aliases",
  "libc",
@@ -2172,7 +2223,7 @@ checksum = "e5dc50790bdee1e91bb3407f58b9529e0de45dc65f7ffb06b514ecdbbd579489"
 dependencies = [
  "indexmap",
  "memchr",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "serde",
  "smallvec",
 ]
@@ -2185,7 +2236,7 @@ checksum = "14057395c16a4230575c6f86bfa074db87e8458626d3e56b20c2454334a7e50c"
 dependencies = [
  "indexmap",
  "memchr",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "serde",
  "smallvec",
 ]
@@ -2259,11 +2310,11 @@ checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
 name = "onig"
-version = "6.5.1"
+version = "6.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "336b9c63443aceef14bea841b899035ae3abe89b7c486aaf4c5bd8aafedac3f0"
+checksum = "0cc3cbf698f9438986c11a880c90a6d04b9de27575afd28bbf45b154b6c709e2"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "libc",
  "once_cell",
  "onig_sys",
@@ -2271,9 +2322,9 @@ dependencies = [
 
 [[package]]
 name = "onig_sys"
-version = "69.9.1"
+version = "69.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7f86c6eef3d6df15f23bcfb6af487cbd2fed4e5581d58d5bf1f5f8b7f6727dc"
+checksum = "1e68317604e77e53b85896388e1a803c1d21b74c899ec9e5e1112db90735edd7"
 dependencies = [
  "cc",
  "pkg-config",
@@ -2311,7 +2362,7 @@ checksum = "abb7a1163a5501f935f8722d839b576491b749c695e7a066aa0b8df988b806df"
 dependencies = [
  "flate2",
  "postcard",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "serde",
  "serde_json",
  "thiserror 2.0.18",
@@ -2340,7 +2391,7 @@ checksum = "b237422b014f8f8fff75bb9379e697d13f8d57551a22c88bebb39f073c1bf696"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2353,7 +2404,7 @@ dependencies = [
  "bumpalo",
  "hashbrown 0.16.1",
  "oxc_data_structures",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
 ]
 
 [[package]]
@@ -2362,7 +2413,7 @@ version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e78ea25d23521092edcd509198635dd0bd96df7fb71349bcd8087bb8f6a615d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "oxc_allocator",
  "oxc_ast_macros",
  "oxc_data_structures",
@@ -2382,7 +2433,7 @@ dependencies = [
  "phf 0.13.1",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2403,7 +2454,7 @@ version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "480bab938439c921d34750708abf15aacf253ea11e2f348e4b085cbf697f4ea2"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "cow-utils",
  "dragonbox_ecma",
  "itoa",
@@ -2415,7 +2466,7 @@ dependencies = [
  "oxc_sourcemap",
  "oxc_span",
  "oxc_syntax",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
 ]
 
 [[package]]
@@ -2427,7 +2478,7 @@ dependencies = [
  "cow-utils",
  "oxc-browserslist",
  "oxc_syntax",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "serde",
 ]
 
@@ -2493,7 +2544,7 @@ dependencies = [
  "oxc_semantic",
  "oxc_span",
  "oxc_syntax",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
 ]
 
 [[package]]
@@ -2518,7 +2569,7 @@ dependencies = [
  "oxc_span",
  "oxc_syntax",
  "oxc_traverse",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
 ]
 
 [[package]]
@@ -2527,7 +2578,7 @@ version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb730ab93ff23bbc471ef7109f847afa709bb284dd52a5d3366283d724858158"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "cow-utils",
  "memchr",
  "num-bigint",
@@ -2540,7 +2591,7 @@ dependencies = [
  "oxc_regular_expression",
  "oxc_span",
  "oxc_syntax",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "seq-macro",
 ]
 
@@ -2550,13 +2601,13 @@ version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27bafc3035e3b0fe555ae56f7bbc108a7ee520b0858250ba16d197e44ca83746"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "oxc_allocator",
  "oxc_ast_macros",
  "oxc_diagnostics",
  "oxc_span",
  "phf 0.13.1",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "unicode-id-start",
 ]
 
@@ -2577,7 +2628,7 @@ dependencies = [
  "oxc_span",
  "oxc_syntax",
  "phf 0.13.1",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "self_cell",
 ]
 
@@ -2589,7 +2640,7 @@ checksum = "6d378eb8bad20e89d66276aebab51f6a5408571092cac94abdd3eabb773713d6"
 dependencies = [
  "base64-simd 0.8.0",
  "json-escape-simd",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "serde",
  "serde_json",
 ]
@@ -2613,7 +2664,7 @@ version = "0.95.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93c99e555ed497111004a71fb2aa6f8fb90b0d3e2733aceeb035e24701d69634"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "cow-utils",
  "dragonbox_ecma",
  "nonmax",
@@ -2642,7 +2693,7 @@ dependencies = [
  "oxc_semantic",
  "oxc_span",
  "oxc_syntax",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
 ]
 
 [[package]]
@@ -2661,13 +2712,13 @@ version = "0.28.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54fd03f1ad26cb6b3ec1b7414fa78a3bd639e7dbb421b1a60513c96ce886a196"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "cssparser 0.33.0",
  "log",
  "phf 0.11.3",
  "phf_codegen 0.11.3",
  "precomputed-hash",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "smallvec",
 ]
 
@@ -2822,7 +2873,7 @@ dependencies = [
  "phf_shared 0.11.3",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2835,7 +2886,7 @@ dependencies = [
  "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2858,25 +2909,25 @@ dependencies = [
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
 name = "plist"
-version = "1.8.0"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "740ebea15c5d1428f910cd1a5f52cebf8d25006245ed8ade92702f4943d91e07"
+checksum = "092791278e026273c1b65bbdcfbba3a300f2994c896bd01ab01da613c29c46f1"
 dependencies = [
  "base64",
  "indexmap",
- "quick-xml 0.38.4",
+ "quick-xml 0.39.4",
  "serde",
  "time",
 ]
@@ -2917,9 +2968,9 @@ checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "portable-atomic-util"
-version = "0.2.5"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a9db96d7fa8782dd8c15ce32ffe8680bbd1e978a43bf51a34d39483540495f5"
+checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
 ]
@@ -2938,9 +2989,9 @@ dependencies = [
 
 [[package]]
 name = "potential_utf"
-version = "0.1.4"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
+checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
@@ -2973,7 +3024,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.114",
+ "syn 2.0.118",
+]
+
+[[package]]
+name = "proc-macro-error-attr2"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+]
+
+[[package]]
+name = "proc-macro-error2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
+dependencies = [
+ "proc-macro-error-attr2",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -2993,9 +3066,9 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec 0.8.0",
- "bitflags",
+ "bitflags 2.13.0",
  "num-traits",
- "rand 0.9.2",
+ "rand 0.9.4",
  "rand_chacha",
  "rand_xorshift",
  "regex-syntax",
@@ -3030,7 +3103,7 @@ version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9f068eba8e7071c5f9511831b44f32c740d5adf574e990f946ddb53db2f314e"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "getopts",
  "memchr",
  "pulldown-cmark-escape",
@@ -3060,9 +3133,9 @@ checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
 
 [[package]]
 name = "quick-xml"
-version = "0.38.4"
+version = "0.39.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66c2058c55a409d601666cffe35f04333cf1013010882cec174a7467cd4e21c"
+checksum = "cdcc8dd4e2f670d309a5f0e83fe36dfdc05af317008fea29144da1a2ac858e5e"
 dependencies = [
  "memchr",
 ]
@@ -3079,9 +3152,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "dfbc457d0c7a0759a614551b11a6409e5951f6c7537be1f1b7682b9ae9230368"
 dependencies = [
  "proc-macro2",
 ]
@@ -3091,6 +3164,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "radium"
@@ -3109,9 +3188,9 @@ dependencies = [
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core 0.9.5",
@@ -3177,7 +3256,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
 ]
 
 [[package]]
@@ -3249,16 +3328,13 @@ dependencies = [
 
 [[package]]
 name = "rss-gen"
-version = "0.0.5"
+version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b80bc3f61d3a43d92302b7d7b1bbc2db17b3f83eeae69f5ab87730829166f592"
+checksum = "3be5690e7b2de7129db714a796f194c861962f2ac88254c48d883c6a2ea38a0b"
 dependencies = [
- "dtt 0.0.10",
- "euxis-commons",
  "log",
  "quick-xml 0.40.1",
  "serde",
- "serde_json",
  "thiserror 2.0.18",
  "time",
  "url",
@@ -3273,9 +3349,9 @@ checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
 
 [[package]]
 name = "rustc-hash"
-version = "2.1.1"
+version = "2.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "357703d41365b4b27c590e3ed91eabb1b663f07c4c084095e60cbed4362dff0d"
+checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustc_version"
@@ -3292,11 +3368,11 @@ version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3395,7 +3471,7 @@ version = "0.26.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fd568a4c9bb598e291a08244a5c1f5a8a6650bee243b5b0f8dbb3d9cc1d87fe8"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "cssparser 0.34.0",
  "derive_more 0.99.20",
  "fxhash",
@@ -3414,7 +3490,7 @@ version = "0.38.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8adfa1c298912827b8a28b223b3b874357397ae706e6190acd9bf28cee99114d"
 dependencies = [
- "bitflags",
+ "bitflags 2.13.0",
  "cssparser 0.37.0",
  "derive_more 2.1.1",
  "log",
@@ -3422,7 +3498,7 @@ dependencies = [
  "phf 0.13.1",
  "phf_codegen 0.13.1",
  "precomputed-hash",
- "rustc-hash 2.1.1",
+ "rustc-hash 2.1.2",
  "servo_arc",
  "smallvec",
 ]
@@ -3435,9 +3511,9 @@ checksum = "b12e76d157a900eb52e81bc6e9f3069344290341720e9178cde2407113ac8d89"
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
 
 [[package]]
 name = "seq-macro"
@@ -3481,7 +3557,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3532,9 +3608,9 @@ checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
 
 [[package]]
 name = "shlex"
-version = "1.3.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook-registry"
@@ -3557,9 +3633,9 @@ dependencies = [
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simdutf8"
@@ -3569,9 +3645,9 @@ checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
 
 [[package]]
 name = "siphasher"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
 
 [[package]]
 name = "sitemap-gen"
@@ -3599,6 +3675,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+
+[[package]]
 name = "slug"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3610,24 +3692,24 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "smawk"
-version = "0.3.2"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c388c1b5e93756d0c740965c41e8822f866621d41acbdf6336a6a168f8840c"
+checksum = "e8e2fb0f499abb4d162f2bedad68f5ef91a1682b5a03596ddb67efd37768d100"
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3644,7 +3726,7 @@ checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
 
 [[package]]
 name = "staticdatagen"
-version = "0.0.9"
+version = "0.0.10"
 dependencies = [
  "anyhow",
  "comrak 0.52.0",
@@ -3677,11 +3759,10 @@ dependencies = [
 
 [[package]]
 name = "staticweaver"
-version = "0.0.2"
+version = "0.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae2a375c7a4feb15ddd81a7a68f093a82d4c8363cf9d1959102434f98f4b90bf"
+checksum = "d358780740c9a469e59253ea11035cbd84911e75f7d62745bd6d955db5deb049"
 dependencies = [
- "askama_escape",
  "fnv",
  "tempfile",
  "thiserror 2.0.18",
@@ -3755,9 +3836,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -3772,7 +3853,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3810,10 +3891,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.1",
+ "getrandom 0.4.3",
  "once_cell",
  "rustix",
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3839,12 +3920,12 @@ dependencies = [
 
 [[package]]
 name = "terminal_size"
-version = "0.4.3"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60b8cb979cb11c32ce1603f8137b22262a9d131aaa5c37b5678025f22b8becd0"
+checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
  "rustix",
- "windows-sys 0.60.2",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3884,7 +3965,7 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3895,7 +3976,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -3930,9 +4011,9 @@ dependencies = [
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "c8323304221c2a851516f22236c5722a72eaa19749016521d6dff0824447d96d"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -3950,9 +4031,9 @@ dependencies = [
 
 [[package]]
 name = "tinyvec"
-version = "1.10.0"
+version = "1.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa5fdc3bce6191a1dbc8c02d5c8bffcf557bafa17c124c5264a458f1b0613fa"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
 dependencies = [
  "tinyvec_macros",
 ]
@@ -3965,9 +4046,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.0"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2bd1c4c0fc4a7ab90fc15ef6daaa3ec3b893f004f915f2392557ed23237820cd"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -3988,7 +4069,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
@@ -4047,7 +4128,7 @@ dependencies = [
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
  "toml_write",
- "winnow 0.7.14",
+ "winnow 0.7.15",
 ]
 
 [[package]]
@@ -4097,9 +4178,9 @@ checksum = "81b79ad29b5e19de4260020f8919b443b2ef0277d242ce532ec7b7a2cc8b6007"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.23"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-linebreak"
@@ -4118,21 +4199,15 @@ dependencies = [
 
 [[package]]
 name = "unicode-segmentation"
-version = "1.12.0"
+version = "1.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
+checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-width"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
-
-[[package]]
-name = "unicode-xid"
-version = "0.2.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "unicode_categories"
@@ -4178,11 +4253,11 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.23.3"
+version = "1.23.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+checksum = "bf80a72845275afea99e7f2b434723d3bc7e38470fcd1c7ed39a599c73319a53"
 dependencies = [
- "getrandom 0.4.1",
+ "getrandom 0.4.3",
  "js-sys",
  "wasm-bindgen",
 ]
@@ -4232,27 +4307,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.4+wasi-0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
-name = "wasip3"
-version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "4b067c0c11094aef6b7a801c1e34a26affafdf3d051dba08456b868789aaf9a4"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -4263,9 +4329,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "167ce5e579f6bcf889c4f7175a8a5a585de84e8ff93976ce393efa5f2837aab1"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -4273,65 +4339,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "f3997c7839262f4ef12cf90b818d6340c18e80f263f1a94bf157d0ec4420380e"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "dc1b4cb0cc549fcf58d7dfc081778139b3d283a081644e833e84682ad71cea24"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
-name = "wasm-encoder"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
-dependencies = [
- "leb128fmt",
- "wasmparser",
-]
-
-[[package]]
-name = "wasm-metadata"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
-dependencies = [
- "anyhow",
- "indexmap",
- "wasm-encoder",
- "wasmparser",
-]
-
-[[package]]
-name = "wasmparser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
-dependencies = [
- "bitflags",
- "hashbrown 0.15.5",
- "indexmap",
- "semver",
-]
-
-[[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.103"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "8622dcb61c0bcc9fffa6938bed81210af2da9a7e4a1a834b2e37a59b6dfb6141"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -4402,7 +4434,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -4423,16 +4455,7 @@ version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -4450,31 +4473,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -4484,22 +4490,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4508,22 +4502,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4532,22 +4514,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4556,28 +4526,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
 dependencies = [
  "memchr",
 ]
@@ -4590,97 +4548,15 @@ checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
-dependencies = [
- "wit-bindgen-rust-macro",
-]
-
-[[package]]
-name = "wit-bindgen-core"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
-dependencies = [
- "anyhow",
- "heck",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-bindgen-rust"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
-dependencies = [
- "anyhow",
- "heck",
- "indexmap",
- "prettyplease",
- "syn 2.0.114",
- "wasm-metadata",
- "wit-bindgen-core",
- "wit-component",
-]
-
-[[package]]
-name = "wit-bindgen-rust-macro"
-version = "0.51.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
-dependencies = [
- "anyhow",
- "prettyplease",
- "proc-macro2",
- "quote",
- "syn 2.0.114",
- "wit-bindgen-core",
- "wit-bindgen-rust",
-]
-
-[[package]]
-name = "wit-component"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
-dependencies = [
- "anyhow",
- "bitflags",
- "indexmap",
- "log",
- "serde",
- "serde_derive",
- "serde_json",
- "wasm-encoder",
- "wasm-metadata",
- "wasmparser",
- "wit-parser",
-]
-
-[[package]]
-name = "wit-parser"
-version = "0.244.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
-dependencies = [
- "anyhow",
- "id-arena",
- "indexmap",
- "log",
- "semver",
- "serde",
- "serde_derive",
- "serde_json",
- "unicode-xid",
- "wasmparser",
-]
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1ffae5123b2d3fc086436f8834ae3ab053a283cfac8fe0a0b8eaae044768a4c4"
 
 [[package]]
 name = "wyz"
@@ -4705,9 +4581,9 @@ checksum = "2fb433233f2df9344722454bc7e96465c9d03bff9d77c248f9e7523fe79585b5"
 
 [[package]]
 name = "xml"
-version = "1.2.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8aa498d22c9bbaf482329839bc5620c46be275a19a812e9a22a2b07529a642a"
+checksum = "636f85e5ca6488e96401b61eb7de54f4e44755c988af0f52cf90230c312a1a89"
 
 [[package]]
 name = "xml-rs"
@@ -4746,9 +4622,9 @@ dependencies = [
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "709fe23a0424b6a435d82152b1bd3fdfb0833487d5fa90d05d42762a9891fef5"
 dependencies = [
  "stable_deref_trait",
  "yoke-derive",
@@ -4757,62 +4633,62 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
 dependencies = [
  "zerocopy-derive",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.8.52"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "0ec05a11813ea801ff6d75110ad09cd0824ddba17dfe17128ea0d5f68e6c5272"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
  "synstructure",
 ]
 
 [[package]]
 name = "zerotrie"
-version = "0.2.3"
+version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
+checksum = "0f9152d31db0792fa83f70fb2f83148effb5c1f5b8c7686c3459e361d9bc20bf"
 dependencies = [
  "displaydoc",
  "yoke",
@@ -4821,9 +4697,9 @@ dependencies = [
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "90f911cbc359ab6af17377d242225f4d75119aec87ea711a880987b18cd7b239"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -4832,17 +4708,17 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.11.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.118",
 ]
 
 [[package]]
 name = "zmij"
-version = "1.0.20"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4de98dfa5d5b7fef4ee834d0073d560c9ca7b6c46a71d058c48db7960f8cfaf7"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -133,6 +133,7 @@ url = "2.5"
 langweave = { version = "0.0.2", optional = true }
 metadata-gen = "0.0.4"
 regex = "1.11.1"
+walkdir = "2"                               # Recursive directory walk for nested-locale `_posts/<lang>/` trees
 rss-gen = "0.0.5"
 sitemap-gen = "0.0.2"
 staticweaver = "0.0.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@
 [package]
 # General project metadata
 name = "staticdatagen"                     # The name of the library
-version = "0.0.9"                          # Current version of the crate
+version = "0.0.10"                         # Current version of the crate
 authors = ["StaticDataGen Contributors"]   # Library contributors
 edition = "2021"                           # Rust edition being used
 rust-version = "1.88.0"                    # Minimum supported Rust version
@@ -102,8 +102,8 @@ version_check = "0.9.5"                       # Ensures that a compatible Rust v
 [dev-dependencies]
 # Dependencies required for testing and development.
 criterion = "0.8.2"                           # Benchmarking library to test performance
-proptest = "1.6"                              # Property-based testing framework
-tempfile = "3"                                # Temporary file/directory creation for tests
+proptest = "1.11"                             # Property-based testing framework
+tempfile = "3.27"                             # Temporary file/directory creation for tests
 
 # -----------------------------------------------------------------------------
 # Dependencies
@@ -132,21 +132,21 @@ url = "2.5"
 # Utilities
 langweave = { version = "0.0.2", optional = true }
 metadata-gen = "0.0.4"
-regex = "1.11.1"
-walkdir = "2"                               # Recursive directory walk for nested-locale `_posts/<lang>/` trees
-rss-gen = "0.0.5"
+regex = "1.12"
+walkdir = "2.5"                             # Recursive directory walk for nested-locale `_posts/<lang>/` trees
+rss-gen = "0.0.6"
 sitemap-gen = "0.0.2"
-staticweaver = "0.0.2"
+staticweaver = "0.0.3"
 time = { version = "0.3", features = ["formatting", "parsing"] }
-uuid = { version = "1.11", features = ["v4"] }
+uuid = { version = "1.23", features = ["v4"] }
 
 # XML processing
 quick-xml = "0.40"
 xml-rs = "1.0"
 
 # CNAME dependencies
-idna = "1.0.3"
-rayon = "1.10.0"
+idna = "1.1"
+rayon = "1.12"
 
 # -----------------------------------------------------------------------------
 # Criterion Benchmark

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,7 +126,7 @@ pulldown-cmark = "0.13"
 html-generator = "0.0.6"
 
 # Web and networking
-http-handle = { version = "0.0.4", optional = true }
+http-handle = { version = "0.0.5", optional = true }
 url = "2.5"
 
 # Utilities
@@ -140,7 +140,7 @@ time = { version = "0.3", features = ["formatting", "parsing"] }
 uuid = { version = "1.11", features = ["v4"] }
 
 # XML processing
-quick-xml = "0.39"
+quick-xml = "0.40"
 xml-rs = "1.0"
 
 # CNAME dependencies

--- a/README.md
+++ b/README.md
@@ -1,11 +1,15 @@
+<!-- SPDX-License-Identifier: Apache-2.0 OR MIT -->
+
 <p align="center">
   <img src="https://cloudcdn.pro/staticdatagen/v1/logos/staticdatagen.svg" alt="StaticDataGen logo" width="128" />
 </p>
 
-<h1 align="center">StaticDataGen</h1>
+<h1 align="center">staticdatagen</h1>
 
 <p align="center">
-  <strong>A Rust library for generating structured data files and metadata for static sites.</strong>
+  The structured-data layer for Rust static sites — HTML, RSS, sitemaps,
+  Open Graph, Twitter Card, and JSON-LD from one content tree, with zero
+  <code>unsafe</code> and the YAML/markdown stack pre-vetted.
 </p>
 
 <p align="center">
@@ -18,70 +22,234 @@
 
 ---
 
+## Contents
+
+**Getting started**
+
+- [Install](#install) — Cargo, MSRV, features
+- [Quick Start](#quick-start) — compile a site in ten lines
+
+**Library reference**
+
+- [Why staticdatagen?](#why-staticdatagen) — design rationale
+- [Capabilities in 0.0.10](#capabilities-in-0010) — release inventory
+- [Modules](#modules) — top-level surface
+- [Library Usage](#library-usage) — `compile`, errors, UUID, version
+- [Configuration](#configuration) — what gets emitted
+- [Examples](#examples) — runnable example index
+
+**Operational**
+
+- [When not to use staticdatagen](#when-not-to-use-staticdatagen) — limitations
+- [Roadmap](#roadmap) — v0.0.11 → v0.0.15
+- [Development](#development) — local loop, CI
+- [Security](#security) — guarantees and audit cadence
+- [Documentation](#documentation) — reference links
+- [License](#license)
+
+---
+
 ## Install
-
-```bash
-cargo add staticdatagen
-```
-
-Or add to `Cargo.toml`:
 
 ```toml
 [dependencies]
 staticdatagen = "0.0.10"
 ```
 
-You need [Rust](https://rustup.rs/) 1.88.0 or later. Works on macOS, Linux, and Windows.
+Or via Cargo:
+
+```bash
+cargo add staticdatagen
+```
+
+### MSRV
+
+| Crate | MSRV | Notes |
+|---|---|---|
+| `staticdatagen` | **1.88.0** | Pinned via `rust-version` in `Cargo.toml`; enforced by the dedicated MSRV CI job. |
+
+Tested on macOS (Intel + Apple Silicon), Linux (x86_64 GNU + musl), and Windows (x86_64-msvc).
+
+### Cargo features
+
+| Feature | Default? | Pulls in | Adds | Status |
+|---|:---:|---|---|---|
+| `full` | ✅ | `rss + sitemap + i18n + server` | Convenience meta-feature (the default). | Stable |
+| `rss` | ✅ (via `full`) | — | RSS feed emission knob. | Currently always-on; per-feature gating tracked in [#78](https://github.com/sebastienrousseau/staticdatagen/issues/78) for v0.0.11. |
+| `sitemap` | ✅ (via `full`) | — | Sitemap + news-sitemap emission knob. | Currently always-on; per-feature gating tracked in [#78](https://github.com/sebastienrousseau/staticdatagen/issues/78) for v0.0.11. |
+| `i18n` | ✅ (via `full`) | `langweave 0.0.2` | Enables the `locales` module for translated string handling. | Active. |
+| `server` | ✅ (via `full`) | `http-handle 0.0.5` | Re-exports `staticdatagen::Server` for serving a built site. | Active. **AGPL transitive — exits in v0.0.12 ([#83](https://github.com/sebastienrousseau/staticdatagen/issues/83))**. |
+| `minimal` | ❌ | — | Reserved for a smaller surface; currently equivalent to disabling `full`. Real gating in v0.0.11 ([#78](https://github.com/sebastienrousseau/staticdatagen/issues/78)). |
+| `async` | ❌ | — | Reserved name; no async surface yet. |
+| `serde` | ❌ | — | Always-on via the unconditional `serde` direct dep. Reserved flag. |
+
+```toml
+# Example: smaller binary, no preview server (no AGPL transitive)
+[dependencies]
+staticdatagen = { version = "0.0.10", default-features = false, features = ["i18n"] }
+```
 
 ---
 
-## Overview
+## Quick Start
 
-StaticDataGen generates the structured data layer for static sites — HTML pages, RSS feeds, sitemaps, and SEO metadata.
-
-- **HTML generation** from templates and content
-- **RSS and Atom feeds** for content syndication
-- **XML sitemaps** for search engine discovery
-- **SEO meta tags** — Open Graph, Twitter Card, JSON-LD
-
----
-
-## Features
-
-| | |
-| :--- | :--- |
-| **HTML generation** | Generate static HTML pages from templates |
-| **RSS feeds** | Create RSS and Atom feeds |
-| **Sitemaps** | Generate XML sitemaps |
-| **SEO meta tags** | Produce Open Graph, Twitter Card, and schema.org metadata |
-| **Structured data** | JSON-LD and microdata output |
-
----
-
-## Usage
+Compile a content tree into a publishable static site. The example
+below is doctest-runnable: every type, function, and import resolves
+in `staticdatagen 0.0.10`.
 
 ```rust,no_run
-use staticdatagen::compiler::service::compile;
+use staticdatagen::compile;
 use std::path::Path;
 
 fn main() -> anyhow::Result<()> {
+    // Inputs:
+    //   - `content/`   markdown files with YAML frontmatter
+    //   - `templates/` HTML templates (staticweaver / MiniJinja syntax)
+    // Outputs (after the build directory is renamed to the site path):
+    //   - `public/index.html`, `public/sitemap.xml`, `public/rss.xml`,
+    //     `public/manifest.json`, `public/robots.txt`, `public/humans.txt`,
+    //     `public/security.txt`, `public/CNAME`, `public/<page>/index.html`.
+    compile(
+        Path::new("build"),      // build_dir_path  — scratch space
+        Path::new("content"),    // content_path    — markdown sources
+        Path::new("public"),     // site_path       — final output root
+        Path::new("templates"),  // template_path   — HTML templates
+    )?;
+    Ok(())
+}
+```
+
+Pre-flight checklist for `content/`:
+
+- Each `.md` file carries YAML frontmatter (`---` delimited).
+- Frontmatter sets at least `title`, `description`, `permalink`.
+- Optional but recommended: `layout` (defaults to `"page"`),
+  `author`, `changefreq`, `last_modified`, `og:image`, `twitter:image`.
+- Subdirectories are walked recursively; per-locale trees
+  (`content/fr/`, `content/_posts/ar/`) are preserved into the
+  output URL.
+
+---
+
+## Why staticdatagen?
+
+The crate covers the *structured-data layer* of a static site — the
+parts a search engine, an RSS reader, an LLM crawler, or a manifest
+consumer parses, as distinct from the HTML body itself.
+
+Three design choices motivate the rewrite from a hand-rolled
+sitemap-plus-RSS pipeline:
+
+1. **One content tree, every artefact.** Frontmatter is parsed once
+   per page (via `metadata-gen`), the rendered HTML is emitted by
+   `comrak` + `staticweaver`, and the same metadata feeds RSS,
+   sitemap, JSON-LD, Open Graph, Twitter Card, manifest, robots,
+   humans, security, and CNAME emitters. No duplication, no drift
+   between the HTML you publish and the metadata that describes it.
+
+2. **`#![forbid(unsafe_code)]` at the crate root.** Every direct
+   dependency is pure-Rust; the YAML stack migrated to `noyalib`
+   (see [v0.0.9 CHANGELOG](CHANGELOG.md)) which drops the C-FFI
+   `libyml` link entirely. `cargo audit`, `cargo deny`, and `miri`
+   gate every push.
+
+3. **Honest defaults.** Missing `layout` resolves to `"page"`,
+   missing `tags/index.html` template no-ops the tag write, missing
+   `main.js` / `sw.js` are debug-logged and skipped instead of
+   aborting the build. The build succeeds for the realistic case
+   where your content tree is mid-evolution.
+
+A few features built on top:
+
+- **Multilingual trees.** `content/<lang>/_posts/...` walks
+  recursively (`walkdir`), the locale prefix is preserved through
+  filename mangling (`with_extension("")`), and the `i18n` feature
+  enables `langweave`-backed translation lookups.
+- **Build-state log fidelity.** The "Successfully generated…" log
+  line fires only *after* the build has truly succeeded — log
+  scrapers (CI, `ssg`) can rely on it as a build-state signal.
+- **Parallel-ready data model.** `FileData` and `PageData` are
+  `Send + Sync`. The compile pipeline parallelises across cores in
+  v0.0.11 ([#74](https://github.com/sebastienrousseau/staticdatagen/issues/74)).
+
+---
+
+## Capabilities in 0.0.10
+
+The 0.0.10 release is a stabilisation pass on the v0.0.9 dep-graph
+slim-down plus five user-reported bug fixes. See
+[`CHANGELOG.md`](CHANGELOG.md) for the full entry.
+
+| Theme | Headline deliverables |
+| :--- | :--- |
+| Bug fixes | Empty `layout:` resolves to `"page"` ([#67]); missing `main.js` / `sw.js` no-op ([#68]); missing tags template no-op ([#69]); recursive walk through subdirectories with locale-preservation ([#70]); success log line fires only after success ([#71]). |
+| Security | `rand` 0.8.5 → 0.8.6 closes GHSA-cq8v-f236-94qc / RUSTSEC-2026-0097 (Stacked-Borrows unsoundness reachable through custom loggers). |
+| Dependencies | `staticweaver` 0.0.2 → 0.0.3, `rss-gen` 0.0.5 → 0.0.6, `regex` 1.11 → 1.12, `walkdir` 2 → 2.5, `uuid` 1.11 → 1.23, `idna` 1.0 → 1.1, `rayon` 1.10 → 1.12. Dev: `proptest` 1.6 → 1.11, `tempfile` 3 → 3.27. |
+| Tests | 714 lib tests, 55 doctests, integration suite green; 0 `cargo audit` vulnerabilities. |
+
+[#67]: https://github.com/sebastienrousseau/staticdatagen/issues/67
+[#68]: https://github.com/sebastienrousseau/staticdatagen/issues/68
+[#69]: https://github.com/sebastienrousseau/staticdatagen/issues/69
+[#70]: https://github.com/sebastienrousseau/staticdatagen/issues/70
+[#71]: https://github.com/sebastienrousseau/staticdatagen/issues/71
+
+---
+
+## Modules
+
+Top-level public modules, in pipeline order.
+
+| Module | Purpose |
+| :--- | :--- |
+| `compiler` | The orchestrator. `compiler::service::compile` walks `content/`, processes each file, and writes the site. |
+| `generators` | Per-artefact emitters: `cname`, `humans`, `manifest`, `news_sitemap`, `tags`. Each is independently callable. |
+| `models` | Core data types: `FileData`, `PageData`, `CnameData`, `SecurityData`, manifest + validation helpers. |
+| `modules` | Cross-cutting passes: `navigation`, `plaintext`, `postprocessor`, `preprocessor`, `robots`, `security`, JSON-LD output. |
+| `utilities` | Reusable helpers: `backup`, `directory`, `element`, `file`, `security` (path sanitization), `uuid`, `write`. |
+| `locales` (`i18n` feature) | Translation lookups via `langweave`. |
+| `macros` | Boilerplate-reduction macros: `macro_create_directories!`, `macro_cleanup_directories!`, `macro_metadata_option!`, `macro_log_info!`. |
+
+---
+
+## Library Usage
+
+<details>
+<summary><b>Compile a site (the common case)</b></summary>
+
+```rust,no_run
+use staticdatagen::compile;
+use std::path::Path;
+
+fn build() -> anyhow::Result<()> {
     compile(
         Path::new("build"),
         Path::new("content"),
         Path::new("public"),
         Path::new("templates"),
     )?;
-    println!("Site data generated!");
     Ok(())
 }
 ```
 
-### Error Handling
+`compile()` is idempotent if `content/` and `templates/` are
+unchanged — the final `fs::rename(build_dir → site_path)` is atomic
+on POSIX. The function returns `anyhow::Result<()>` in v0.0.10;
+v0.0.11 ([#73]) promotes the typed
+[`staticdatagen::Error`](https://docs.rs/staticdatagen/latest/staticdatagen/enum.Error.html)
+to the public surface.
 
-All operations return typed errors that can be matched:
+[#73]: https://github.com/sebastienrousseau/staticdatagen/issues/73
+
+</details>
+
+<details>
+<summary><b>Error handling</b></summary>
+
+The internal `Error` enum is exported; today `compile()` returns
+`anyhow::Result<()>` so downcasting is the access path.
 
 ```rust,no_run
-use staticdatagen::{compiler::service::compile, Error};
+use staticdatagen::{compile, Error};
 use std::path::Path;
 
 fn main() {
@@ -93,32 +261,275 @@ fn main() {
     );
 
     match result {
-        Ok(()) => println!("Success!"),
-        Err(ref e) => match e.downcast_ref::<Error>() {
+        Ok(()) => println!("Site built."),
+        Err(e) => match e.downcast_ref::<Error>() {
             Some(Error::Io { context, .. }) => {
-                eprintln!("IO error: {context}");
+                eprintln!("I/O failed: {context}");
             }
             Some(Error::Template(msg)) => {
                 eprintln!("Template error: {msg}");
             }
-            _ => eprintln!("Error: {e}"),
+            Some(Error::ContentProcessing { message, .. }) => {
+                eprintln!("Content error: {message}");
+            }
+            Some(Error::Config(msg)) => eprintln!("Config error: {msg}"),
+            Some(Error::Other(msg)) => eprintln!("Error: {msg}"),
+            None => eprintln!("Wrapped error: {e:#}"),
         },
     }
 }
 ```
+
+</details>
+
+<details>
+<summary><b>Build a typed error</b></summary>
+
+```rust
+use staticdatagen::{Error, ErrorSeverity};
+
+let err = Error::content_processing_builder()
+    .message("Invalid frontmatter")
+    .context("expected key `title`")
+    .severity(ErrorSeverity::Error)
+    .build();
+
+assert!(matches!(err, Error::ContentProcessing { .. }));
+```
+
+The matching `IoErrorBuilder` mirrors the pattern for
+[`Error::Io`](https://docs.rs/staticdatagen/latest/staticdatagen/enum.Error.html#variant.Io)
+with `.source`, `.operation`, `.path`, and `.context` setters.
+
+</details>
+
+<details>
+<summary><b>Unique identifiers</b></summary>
+
+```rust
+use staticdatagen::generate_unique_string;
+
+let id_a = generate_unique_string();
+let id_b = generate_unique_string();
+
+// UUID v4: 36 characters with hyphens.
+assert_eq!(id_a.len(), 36);
+assert_ne!(id_a, id_b);
+```
+
+</details>
+
+<details>
+<summary><b>Version constant</b></summary>
+
+```rust
+// VERSION is sourced from CARGO_PKG_VERSION at build time.
+println!("staticdatagen {}", staticdatagen::VERSION);
+```
+
+</details>
+
+<details>
+<summary><b>Serve the built site (<code>server</code> feature)</b></summary>
+
+```rust,ignore
+# // Requires the `server` feature.
+use staticdatagen::Server;
+use std::path::Path;
+
+// Re-exported from `http_handle` — see that crate's docs for the
+// full configuration surface. AGPL transitive in v0.0.10; replaced
+// by `axum` in v0.0.12 (#83).
+let _server = Server::new("127.0.0.1:3000", Path::new("public"));
+```
+
+</details>
+
+---
+
+## Configuration
+
+`compile()` takes four paths; everything else is driven by per-page
+YAML frontmatter. The recognised keys (parsed by `metadata-gen`)
+include:
+
+| Key | Type | Purpose |
+| :--- | :--- | :--- |
+| `title` | string | Page `<title>`, Open Graph, RSS item title. |
+| `description` | string | Meta description, RSS item, JSON-LD. |
+| `permalink` | URL | Canonical URL, used by sitemap, RSS, manifest. |
+| `layout` | string | Template name (without `.html`). Defaults to `"page"` when absent. |
+| `author` | string | RSS `<author>`, JSON-LD `author`. |
+| `changefreq` | string | sitemap `<changefreq>`. |
+| `last_modified` | RFC 3339 / RFC 2822 date | sitemap `<lastmod>`, news-sitemap. |
+| `tags` | comma-separated | Tag aggregation into `tags/index.html`. |
+| `og:image`, `twitter:image` | URL | Social cards. |
+| `cname` | hostname | Written to `CNAME`. |
+| `news_genres`, `news_keywords`, `news_publication_date` | strings | News sitemap fields. |
+
+Files emitted to the site root: `index.html`, `manifest.json`,
+`robots.txt`, `humans.txt`, `security.txt`, `sitemap.xml`,
+`news-sitemap.xml`, `rss.xml`, `CNAME`. Non-index pages land at
+`<page>/index.html`.
+
+---
+
+## Examples
+
+25 runnable examples ship under `examples/`. Each one is built and
+linted in CI.
+
+| Surface | Example | Run with |
+| :--- | :--- | :--- |
+| End-to-end | `service_example.rs` | `cargo run --example service_example` |
+| End-to-end | `compiler_example.rs` | `cargo run --example compiler_example` |
+| End-to-end | `static_site_example.rs` | `cargo run --example static_site_example` |
+| End-to-end | `lib_example.rs` | `cargo run --example lib_example` |
+| Generator | `cname_example.rs` | `cargo run --example cname_example` |
+| Generator | `humans_example.rs` | `cargo run --example humans_example` |
+| Generator | `manifest_example.rs` | `cargo run --example manifest_example` |
+| Generator | `news_sitemap_example.rs` | `cargo run --example news_sitemap_example` |
+| Generator | `tags_example.rs` | `cargo run --example tags_example` |
+| Generator | `security_example.rs` | `cargo run --example security_example` |
+| Generator | `robots_example.rs` | `cargo run --example robots_example` |
+| Module | `navigation_example.rs` | `cargo run --example navigation_example` |
+| Module | `plaintext_example.rs` | `cargo run --example plaintext_example` |
+| Module | `postprocessor_example.rs` | `cargo run --example postprocessor_example` |
+| Module | `preprocessor_example.rs` | `cargo run --example preprocessor_example` |
+| Module | `json_example.rs` | `cargo run --example json_example` |
+| Models | `data_example.rs` | `cargo run --example data_example` |
+| Utilities | `backup_example.rs` | `cargo run --example backup_example` |
+| Utilities | `directory_example.rs` | `cargo run --example directory_example` |
+| Utilities | `element_example.rs` | `cargo run --example element_example` |
+| Utilities | `file_example.rs` | `cargo run --example file_example` |
+| Utilities | `uuid_example.rs` | `cargo run --example uuid_example` |
+| Utilities | `write_example.rs` | `cargo run --example write_example` |
+| i18n | `locales_de_example.rs` | `cargo run --example locales_de_example --features i18n` |
+| i18n | `locales_fr_example.rs` | `cargo run --example locales_fr_example --features i18n` |
+
+A narrative *learn → integrate → extend* ladder lands in v0.0.15
+([#98](https://github.com/sebastienrousseau/staticdatagen/issues/98)).
+
+---
+
+## When not to use staticdatagen
+
+- **You want a full SSG, not the structured-data layer.** Reach for
+  [Zola](https://www.getzola.org/), [Cobalt](https://cobalt-org.github.io/),
+  or [Hugo](https://gohugo.io/). `staticdatagen` is the library that
+  emits the parts a search engine, RSS reader, or LLM crawler reads —
+  it does not ship a CLI, theme system, or asset pipeline.
+- **You need a non-Rust runtime today.** WASI 0.2 Component Model
+  distribution lands in v0.0.14
+  ([#90](https://github.com/sebastienrousseau/staticdatagen/issues/90));
+  Python / Node FFIs in v0.0.15
+  ([#96](https://github.com/sebastienrousseau/staticdatagen/issues/96),
+  [#97](https://github.com/sebastienrousseau/staticdatagen/issues/97)).
+- **You need true incremental rebuilds.** v0.0.10 rebuilds every
+  file. Content-hash-based incremental cache lands in v0.0.13
+  ([#87](https://github.com/sebastienrousseau/staticdatagen/issues/87),
+  closes long-standing
+  [#36](https://github.com/sebastienrousseau/staticdatagen/issues/36)).
+
+---
+
+## Roadmap
+
+| Milestone | Theme | Highlights |
+| :--- | :--- | :--- |
+| [v0.0.11](https://github.com/sebastienrousseau/staticdatagen/milestone/1) | Tier-1 quick wins | Typed `Error` ([#73]), parallel pipeline ([#74]), drop `pulldown-cmark` ([#75]), `cargo-vet` ([#76]), SBOM ([#77]), real feature gating ([#78]). |
+| [v0.0.12](https://github.com/sebastienrousseau/staticdatagen/milestone/2) | DX & observability | `CompileBuilder` ([#79]), `tracing` migration ([#80]), `cargo-fuzz` ([#81]), Loom ([#82]), AGPL exit / `axum` ([#83]), god-object split ([#84]). |
+| [v0.0.13](https://github.com/sebastienrousseau/staticdatagen/milestone/3) | AI-discoverable static sites | `llms.txt` ([#85]), AI sitemap ([#86]), incremental cache ([#87], closes [#36]), ADRs ([#88]), public Criterion charts ([#89]). |
+| [v0.0.14](https://github.com/sebastienrousseau/staticdatagen/milestone/4) | Portability | WASI 0.2 component ([#90]), `no_std + alloc` core split ([#91]), `Reporter` trait ([#92]), architecture diagram ([#93]). |
+| [v0.0.15](https://github.com/sebastienrousseau/staticdatagen/milestone/5) | Correctness & GTM | Kani proofs ([#94]), differential fuzz ([#95]), PyO3 binding ([#96]), NAPI binding ([#97]), README + examples ladder ([#98]). |
+
+[#36]: https://github.com/sebastienrousseau/staticdatagen/issues/36
+[#73]: https://github.com/sebastienrousseau/staticdatagen/issues/73
+[#74]: https://github.com/sebastienrousseau/staticdatagen/issues/74
+[#75]: https://github.com/sebastienrousseau/staticdatagen/issues/75
+[#76]: https://github.com/sebastienrousseau/staticdatagen/issues/76
+[#77]: https://github.com/sebastienrousseau/staticdatagen/issues/77
+[#78]: https://github.com/sebastienrousseau/staticdatagen/issues/78
+[#79]: https://github.com/sebastienrousseau/staticdatagen/issues/79
+[#80]: https://github.com/sebastienrousseau/staticdatagen/issues/80
+[#81]: https://github.com/sebastienrousseau/staticdatagen/issues/81
+[#82]: https://github.com/sebastienrousseau/staticdatagen/issues/82
+[#83]: https://github.com/sebastienrousseau/staticdatagen/issues/83
+[#84]: https://github.com/sebastienrousseau/staticdatagen/issues/84
+[#85]: https://github.com/sebastienrousseau/staticdatagen/issues/85
+[#86]: https://github.com/sebastienrousseau/staticdatagen/issues/86
+[#87]: https://github.com/sebastienrousseau/staticdatagen/issues/87
+[#88]: https://github.com/sebastienrousseau/staticdatagen/issues/88
+[#89]: https://github.com/sebastienrousseau/staticdatagen/issues/89
+[#90]: https://github.com/sebastienrousseau/staticdatagen/issues/90
+[#91]: https://github.com/sebastienrousseau/staticdatagen/issues/91
+[#92]: https://github.com/sebastienrousseau/staticdatagen/issues/92
+[#93]: https://github.com/sebastienrousseau/staticdatagen/issues/93
+[#94]: https://github.com/sebastienrousseau/staticdatagen/issues/94
+[#95]: https://github.com/sebastienrousseau/staticdatagen/issues/95
+[#96]: https://github.com/sebastienrousseau/staticdatagen/issues/96
+[#97]: https://github.com/sebastienrousseau/staticdatagen/issues/97
+[#98]: https://github.com/sebastienrousseau/staticdatagen/issues/98
 
 ---
 
 ## Development
 
 ```bash
-cargo build        # Build the project
-cargo test         # Run all tests
-cargo clippy       # Lint with Clippy
-cargo fmt          # Format with rustfmt
+git clone https://github.com/sebastienrousseau/staticdatagen.git
+cd staticdatagen
+make                  # fmt + clippy + test (see Makefile)
+cargo build           # debug build
+cargo test            # 714 lib + 55 doc tests + integration suite
+cargo clippy          # -D warnings is enforced
+cargo bench           # Criterion benches under benches/
 ```
 
-See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, signed commits, and PR guidelines.
+CI runs on every push:
+
+- **Build matrix**: stable, beta, nightly, MSRV (1.88.0) on Linux,
+  macOS, and Windows.
+- **Miri**: `cargo miri test models -- --skip proptest`,
+  `cargo miri test utilities::element`, `utilities::uuid`, `locales`,
+  `macros::directory`, `macros::custom`.
+- **Coverage**: `cargo llvm-cov` reported to Codecov.
+- **Supply chain**: `cargo audit`, `cargo deny`. `cargo vet` lands
+  in v0.0.11
+  ([#76](https://github.com/sebastienrousseau/staticdatagen/issues/76)).
+
+See [CONTRIBUTING.md](CONTRIBUTING.md) for signed-commit setup and
+PR guidelines.
+
+---
+
+## Security
+
+- **`#![forbid(unsafe_code)]`** at the crate root. Verified on every
+  push.
+- **`#![deny(clippy::unwrap_used, clippy::expect_used)]`** for
+  non-test code. Library code paths cannot panic on `unwrap`.
+- **Property tests** under `proptest-regressions/` cover the path
+  sanitization surface (`utilities::security`).
+- **Audit cadence.** `deny.toml` records a quarterly review schedule
+  (next: 2026-07-17) and lists every transitive exemption with a
+  justification.
+- **Vulnerability disclosure.** See [SECURITY.md](.github/SECURITY.md).
+- **SBOM** publication lands in v0.0.11
+  ([#77](https://github.com/sebastienrousseau/staticdatagen/issues/77));
+  Kani proofs in v0.0.15
+  ([#94](https://github.com/sebastienrousseau/staticdatagen/issues/94)).
+
+---
+
+## Documentation
+
+- API reference: <https://docs.rs/staticdatagen>
+- Crate page: <https://crates.io/crates/staticdatagen>
+- Project site: <https://staticdatagen.com>
+- Changelog: [`CHANGELOG.md`](CHANGELOG.md)
+- Contributing: [`CONTRIBUTING.md`](CONTRIBUTING.md)
+- Security policy: [`.github/SECURITY.md`](.github/SECURITY.md)
+- Authors: [`AUTHORS.md`](AUTHORS.md)
 
 ---
 
@@ -129,6 +540,7 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for setup, signed commits, and PR guideli
 
 ## License
 
-Dual-licensed under [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0) or [MIT](https://opensource.org/licenses/MIT), at your option.
+Dual-licensed under [Apache 2.0](https://www.apache.org/licenses/LICENSE-2.0)
+or [MIT](https://opensource.org/licenses/MIT), at your option.
 
 <p align="right"><a href="#staticdatagen">Back to Top</a></p>

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
   <a href="https://crates.io/crates/staticdatagen"><img src="https://img.shields.io/crates/v/staticdatagen.svg?style=for-the-badge&color=fc8d62&logo=rust" alt="Crates.io" /></a>
   <a href="https://docs.rs/staticdatagen"><img src="https://img.shields.io/badge/docs.rs-staticdatagen-66c2a5?style=for-the-badge&labelColor=555555&logo=docs.rs" alt="Docs.rs" /></a>
   <a href="https://codecov.io/gh/sebastienrousseau/staticdatagen"><img src="https://img.shields.io/codecov/c/github/sebastienrousseau/staticdatagen?style=for-the-badge&logo=codecov" alt="Coverage" /></a>
-  <a href="https://lib.rs/crates/staticdatagen"><img src="https://img.shields.io/badge/lib.rs-v0.0.9-orange.svg?style=for-the-badge" alt="lib.rs" /></a>
+  <a href="https://lib.rs/crates/staticdatagen"><img src="https://img.shields.io/badge/lib.rs-v0.0.10-orange.svg?style=for-the-badge" alt="lib.rs" /></a>
 </p>
 
 ---
@@ -28,7 +28,7 @@ Or add to `Cargo.toml`:
 
 ```toml
 [dependencies]
-staticdatagen = "0.0.9"
+staticdatagen = "0.0.10"
 ```
 
 You need [Rust](https://rustup.rs/) 1.88.0 or later. Works on macOS, Linux, and Windows.

--- a/src/compiler/service.rs
+++ b/src/compiler/service.rs
@@ -98,12 +98,6 @@ pub fn compile(
         })
         .collect();
 
-    // Log compilation completion message.
-    info!(
-        "Successfully generated, compiled, and minified all HTML to the `{}` directory",
-        site_path.display()
-    );
-
     // Write each compiled file to the output directory.
     for file in &compiled_files? {
         write_files_to_build_directory(
@@ -122,6 +116,15 @@ pub fn compile(
         .context("Failed to clean up site directory")?;
     fs::rename(build_dir_path, site_path)
         .context("Failed to finalize build directory")?;
+
+    // Issue #71: only log success AFTER every fallible step (write,
+    // tags HTML, cleanup, rename) has completed. Downstream consumers
+    // (ssg, CI tooling) parse this line for build state, so it must
+    // never fire on a build that later errors out.
+    info!(
+        "Successfully generated, compiled, and minified all HTML to the `{}` directory",
+        site_path.display()
+    );
 
     Ok(())
 }

--- a/src/compiler/service.rs
+++ b/src/compiler/service.rs
@@ -442,10 +442,15 @@ fn process_file(
     context.set("primary".to_string(), all_meta_tags.primary);
     context.set("twitter".to_string(), all_meta_tags.twitter);
 
-    let content = engine.render_page(
-        &context,
-        metadata.get("layout").cloned().unwrap_or_default().as_str(),
-    )?;
+    // Default to `page` when frontmatter omits `layout:` (or sets it
+    // to an empty/whitespace value); staticweaver otherwise aborts with
+    // `invalid template or partial name: ""`. Issue #67.
+    let layout = metadata
+        .get("layout")
+        .map(|s| s.trim())
+        .filter(|s| !s.is_empty())
+        .unwrap_or("page");
+    let content = engine.render_page(&context, layout)?;
 
     // Generate RSS, manifest and auxiliary files
     let rss_content = generate_rss_content(&metadata)?;
@@ -1370,5 +1375,53 @@ Content here"#;
         let content = generate_manifest_content(&metadata);
         // Should produce a valid manifest or be empty if ManifestConfig fails
         let _ = content; // exercised the code path
+    }
+
+    #[test]
+    fn test_compile_defaults_layout_when_missing() {
+        // Regression for sebastienrousseau/staticdatagen#67.
+        // Frontmatter without a `layout:` key used to pass "" to
+        // staticweaver, which then errored with "invalid template or
+        // partial name". After the fix, "page" is used as the default.
+        let build_dir = tempfile::TempDir::new().unwrap();
+        let content_dir = tempfile::TempDir::new().unwrap();
+        let site_dir = tempfile::TempDir::new().unwrap();
+        let template_dir = tempfile::TempDir::new().unwrap();
+
+        // Frontmatter intentionally omits `layout:`.
+        fs::write(
+            content_dir.path().join("index.md"),
+            "---\ntitle: Home\npermalink: https://example.com\ndescription: Home page\nauthor: Test\nchangefreq: weekly\n---\n# Welcome\n",
+        )
+        .unwrap();
+
+        fs::write(
+            template_dir.path().join("page.html"),
+            "<html><body>{{content}}</body></html>",
+        )
+        .unwrap();
+        fs::write(template_dir.path().join("main.js"), "// main")
+            .unwrap();
+        fs::write(template_dir.path().join("sw.js"), "// sw").unwrap();
+
+        fs::create_dir_all(build_dir.path().join("tags")).unwrap();
+        fs::write(
+            build_dir.path().join("tags/index.html"),
+            "<html><body>[[content]]</body></html>",
+        )
+        .unwrap();
+
+        let result = compile(
+            build_dir.path(),
+            content_dir.path(),
+            site_dir.path(),
+            template_dir.path(),
+        );
+
+        assert!(
+            result.is_ok(),
+            "compile should succeed when layout key is absent: {:?}",
+            result.err()
+        );
     }
 }

--- a/src/generators/tags.rs
+++ b/src/generators/tags.rs
@@ -303,6 +303,19 @@ pub fn write_tags_html_to_file(
 ) -> io::Result<()> {
     let file_path = output_path.join("tags/index.html");
 
+    // Issue #69: a missing tags template means the user hasn't asked
+    // for a tags page — silently skip rather than aborting the whole
+    // build with an opaque `os error 2` after every other artefact is
+    // already written. Users opt in by checking `tags.md` (or
+    // `tags/index.md`) into content/.
+    if !file_path.exists() {
+        debug!(
+            "tags template '{}' not present — skipping tags HTML write",
+            file_path.display()
+        );
+        return Ok(());
+    }
+
     let mut file = fs::File::open(&file_path)?;
     let mut base_html = String::new();
     // Use `_ = ...` to ignore number-of-bytes result
@@ -608,10 +621,20 @@ mod tests {
 
     #[test]
     fn test_write_tags_html_to_file_missing_file() {
+        // Regression for sebastienrousseau/staticdatagen#69.
+        // Before the fix, missing `tags/index.html` aborted the build
+        // with `os error 2`. After the fix, it's a silent no-op
+        // (debug log) so sites without a tags page build cleanly.
         let temp_dir = tempfile::TempDir::new().unwrap();
         let result =
             write_tags_html_to_file("<p>Tags</p>", temp_dir.path());
-        assert!(result.is_err());
+        assert!(
+            result.is_ok(),
+            "missing tags page should now be a no-op: {:?}",
+            result.err()
+        );
+        // And nothing should have been created.
+        assert!(!temp_dir.path().join("tags/index.html").exists());
     }
 
     #[test]

--- a/src/utilities/file.rs
+++ b/src/utilities/file.rs
@@ -5,77 +5,96 @@ use crate::models::data::FileData;
 use log::warn;
 use quick_xml::escape::escape;
 use std::{fs, io, path::Path};
+use walkdir::WalkDir;
 
 /// Maximum file size in bytes (10 MiB).
 const MAX_FILE_SIZE: u64 = 10 * 1024 * 1024;
 
-/// Reads all files in a directory specified by the given path and returns a vector of FileData.
+/// Reads all files in a directory (recursively) and returns a vector of FileData.
 ///
-/// Each file is represented as a `FileData` struct containing the name and content of the file.
+/// Each file is represented as a `FileData` struct containing the
+/// directory-relative path (e.g. `fr/article.md` for a per-locale
+/// `_posts/<lang>/` tree) as `name`, and the raw + entity-escaped
+/// content. Subdirectories are walked transparently, which is what
+/// makes the multilingual `_posts/<lang>/<slug>.md` pattern build
+/// without per-locale shims. Issue #70.
+///
+/// Files named `.DS_Store` and files exceeding `MAX_FILE_SIZE` (10 MiB)
+/// are skipped at any depth. Non-UTF-8 files are skipped with a
+/// warning. The walk follows symlinks; relying on cycles is undefined.
 ///
 /// # Arguments
 ///
-/// * `path` - A `Path` representing the directory containing the files to be read.
+/// * `path` - A `Path` representing the root directory containing the
+///   files (and optional subdirectories) to be read.
 ///
 /// # Returns
 ///
-/// A `Result` containing a vector of `FileData` structs representing all files in the directory,
-/// or an `io::Error` if the directory cannot be read.
+/// A `Result` containing a vector of `FileData` structs for every
+/// reachable file, or an `io::Error` if the directory cannot be opened.
 pub fn add(path: &Path) -> io::Result<Vec<FileData>> {
-    let files = fs::read_dir(path)?
-        .filter_map(|entry| {
-            let entry = entry.ok()?;
-            let path = entry.path();
-            if path.is_file() {
-                let file_name =
-                    path.file_name()?.to_string_lossy().to_string();
-                if file_name == ".DS_Store" {
-                    return None;
-                }
-                // Check file size before reading to prevent memory exhaustion
-                if let Ok(metadata) = fs::metadata(&path) {
-                    if metadata.len() > MAX_FILE_SIZE {
-                        warn!(
-                            "Skipping oversized file {:?} ({} bytes, limit {})",
-                            path, metadata.len(), MAX_FILE_SIZE
-                        );
-                        return None;
-                    }
-                }
-                let content = fs::read_to_string(&path)
-                    .map_err(|e| {
-                        warn!(
-                            "Error reading file {:?}: {}",
-                            path, e
-                        );
-                        e
-                    })
-                    .ok()?;
-                Some((file_name, content))
-            } else {
-                None
-            }
-        })
-        .map(|(file_name, content)| {
-            let escaped = escape(&content).to_string();
+    // Probe the root once so a missing-dir surfaces as io::Error
+    // (matches the pre-#70 contract that downstream tests rely on).
+    let _ = fs::read_dir(path)?;
 
-            FileData {
-                cname: escaped.clone(),
-                keyword: escaped.clone(),
-                manifest: escaped.clone(),
-                rss: escaped.clone(),
-                sitemap: escaped.clone(),
-                sitemap_news: escaped,
-                human: content.clone(),
-                security: content.clone(),
-                txt: content.clone(),
-                name: file_name,
-                content,
-            }
-        })
-        .collect::<Vec<FileData>>();
+    let mut out = Vec::new();
+    for entry in WalkDir::new(path).into_iter().filter_map(Result::ok) {
+        if !entry.file_type().is_file() {
+            continue;
+        }
+        let abs = entry.path();
+        let rel = abs.strip_prefix(path).unwrap_or(abs);
+        // Use forward slashes regardless of platform — these names
+        // become URL path components downstream.
+        let file_name = rel
+            .components()
+            .map(|c| c.as_os_str().to_string_lossy())
+            .collect::<Vec<_>>()
+            .join("/");
 
-    Ok(files)
+        // Skip `.DS_Store` whether at root or nested.
+        if rel.file_name().map(|f| f == ".DS_Store").unwrap_or(false) {
+            continue;
+        }
+
+        // Reject files exceeding MAX_FILE_SIZE so the process can't
+        // be OOM'd by a stray binary in the content tree.
+        if let Ok(metadata) = fs::metadata(abs) {
+            if metadata.len() > MAX_FILE_SIZE {
+                warn!(
+                    "Skipping oversized file {:?} ({} bytes, limit {})",
+                    abs,
+                    metadata.len(),
+                    MAX_FILE_SIZE
+                );
+                continue;
+            }
+        }
+
+        let content = match fs::read_to_string(abs) {
+            Ok(c) => c,
+            Err(e) => {
+                warn!("Error reading file {:?}: {}", abs, e);
+                continue;
+            }
+        };
+
+        let escaped = escape(&content).to_string();
+        out.push(FileData {
+            cname: escaped.clone(),
+            keyword: escaped.clone(),
+            manifest: escaped.clone(),
+            rss: escaped.clone(),
+            sitemap: escaped.clone(),
+            sitemap_news: escaped,
+            human: content.clone(),
+            security: content.clone(),
+            txt: content.clone(),
+            name: file_name,
+            content,
+        });
+    }
+    Ok(out)
 }
 
 #[cfg(test)]
@@ -206,23 +225,36 @@ mod tests {
         Ok(())
     }
 
-    /// Tests that `add` skips over non-file entries (e.g., subdirectories).
+    /// Tests that `add` walks into subdirectories (issue #70).
+    ///
+    /// Pre-#70 this test asserted the opposite — that subdirectories
+    /// were silently skipped, which broke every `_posts/<lang>/`
+    /// multilingual tree. Post-#70 the recursive walk picks them up.
     #[test]
-    fn test_add_skips_directories() -> io::Result<()> {
+    fn test_add_walks_into_subdirectories() -> io::Result<()> {
         let dir = tempdir()?;
         let subdir_path = dir.path().join("subdir");
-        let file_path = dir.path().join("test_file.txt");
+        let root_file = dir.path().join("root.txt");
 
-        // Create a subdirectory and a test file in the main directory
         fs::create_dir(&subdir_path)?;
-        File::create(&file_path)?.write_all(b"Content in file")?;
+        File::create(&root_file)?.write_all(b"root content")?;
+        File::create(subdir_path.join("nested.txt"))?
+            .write_all(b"nested content")?;
 
-        // Run the `add` function
         let files = add(dir.path())?;
 
-        // Verify that only the file is read, and the subdirectory is ignored
-        assert_eq!(files.len(), 1);
-        assert_eq!(files[0].name, "test_file.txt");
+        // Both root and nested files should be read.
+        assert_eq!(files.len(), 2);
+        let names: Vec<&str> =
+            files.iter().map(|f| f.name.as_str()).collect();
+        assert!(
+            names.contains(&"root.txt"),
+            "expected root.txt, got: {names:?}"
+        );
+        assert!(
+            names.contains(&"subdir/nested.txt"),
+            "expected subdir/nested.txt (with parent prefix), got: {names:?}"
+        );
 
         Ok(())
     }
@@ -293,6 +325,72 @@ mod tests {
         // Assert
         assert_eq!(files.len(), 1, "Oversized file should be skipped");
         assert_eq!(files[0].name, "small.txt");
+        Ok(())
+    }
+
+    /// Tests that `add` preserves the directory-relative path on
+    /// every `FileData::name`, using forward slashes regardless of
+    /// platform — the names round-trip into URL path components.
+    #[test]
+    fn test_add_preserves_locale_subdirectory_prefix() -> io::Result<()>
+    {
+        // Mirror the Jekyll `_posts/<lang>/<slug>.md` shape.
+        let dir = tempdir()?;
+        for locale in ["en", "fr", "de"] {
+            let sub = dir.path().join(locale);
+            fs::create_dir(&sub)?;
+            File::create(sub.join("hello.md"))?
+                .write_all(format!("hello-{locale}").as_bytes())?;
+        }
+
+        let files = add(dir.path())?;
+
+        assert_eq!(files.len(), 3);
+        let names: Vec<&str> =
+            files.iter().map(|f| f.name.as_str()).collect();
+        for locale in ["en", "fr", "de"] {
+            let expected = format!("{locale}/hello.md");
+            assert!(
+                names.contains(&expected.as_str()),
+                "expected name {expected:?} in {names:?}"
+            );
+        }
+        Ok(())
+    }
+
+    /// Tests that `.DS_Store` is filtered out at ANY depth, not just
+    /// at the root.
+    #[test]
+    fn test_add_skips_ds_store_recursively() -> io::Result<()> {
+        let dir = tempdir()?;
+        let nested = dir.path().join("fr");
+        fs::create_dir(&nested)?;
+        File::create(dir.path().join(".DS_Store"))?
+            .write_all(b"junk")?; // root-level junk
+        File::create(nested.join(".DS_Store"))?.write_all(b"junk")?; // nested junk
+        File::create(nested.join("article.md"))?
+            .write_all(b"keep me")?;
+
+        let files = add(dir.path())?;
+
+        assert_eq!(files.len(), 1, "only article.md should remain");
+        assert_eq!(files[0].name, "fr/article.md");
+        Ok(())
+    }
+
+    /// Tests deep nesting (3+ levels) so the recursion can't be
+    /// silently capped at a single level.
+    #[test]
+    fn test_add_handles_deep_nesting() -> io::Result<()> {
+        let dir = tempdir()?;
+        let deep = dir.path().join("a").join("b").join("c");
+        fs::create_dir_all(&deep)?;
+        File::create(deep.join("buried.md"))?.write_all(b"deep")?;
+
+        let files = add(dir.path())?;
+
+        assert_eq!(files.len(), 1);
+        assert_eq!(files[0].name, "a/b/c/buried.md");
         Ok(())
     }
 }

--- a/src/utilities/write.rs
+++ b/src/utilities/write.rs
@@ -387,6 +387,17 @@ fn copy_auxiliary_files(
         build_dir_path.display()
     );
     for file_name in &OTHER_FILES {
+        // Issue #68: make the copy best-effort. Most sites don't ship
+        // a service worker today, so missing `main.js` / `sw.js` is
+        // expected — don't abort the whole build over it.
+        let src = template_path.join(file_name);
+        if !src.exists() {
+            debug!(
+                "auxiliary file '{}' not present in templates — skipping",
+                file_name
+            );
+            continue;
+        }
         debug!("Copying auxiliary file: '{}'", file_name);
         copy_template_file(template_path, build_dir_path, file_name)
             .with_context(|| {
@@ -850,14 +861,26 @@ mod tests {
 
     #[test]
     fn test_copy_auxiliary_files_missing() {
+        // Regression for sebastienrousseau/staticdatagen#68.
+        // Before the fix, copy_auxiliary_files aborted with `os error 2`
+        // when `main.js` or `sw.js` were absent from templates/. After
+        // the fix, missing auxiliary files are skipped silently (debug
+        // log) and the build continues.
         let template_dir = TempDir::new().unwrap();
         let build_dir = TempDir::new().unwrap();
 
-        // Don't create the files - should fail
+        // Templates dir is empty — no main.js, no sw.js.
         let result =
             copy_auxiliary_files(template_dir.path(), build_dir.path());
 
-        assert!(result.is_err());
+        assert!(
+            result.is_ok(),
+            "copy_auxiliary_files should succeed when files are absent: {:?}",
+            result.err()
+        );
+        // And nothing should have been copied.
+        assert!(!build_dir.path().join("main.js").exists());
+        assert!(!build_dir.path().join("sw.js").exists());
     }
 
     #[test]

--- a/src/utilities/write.rs
+++ b/src/utilities/write.rs
@@ -137,11 +137,13 @@ fn get_processed_file_name(original_name: &str) -> String {
 
     if let Some(ext) = extension {
         if ["js", "json", "md", "toml", "txt", "xml"].contains(&ext) {
-            let processed = path
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .unwrap_or(original_name)
-                .to_string();
+            // Issue #70: preserve parent directories (per-locale
+            // subdirs like `fr/`) when stripping the extension —
+            // `path.file_stem()` would drop them and the locale
+            // prefix would never reach the output URL. Using
+            // `with_extension("")` keeps the relative path intact.
+            let processed =
+                path.with_extension("").to_string_lossy().to_string();
             debug!("Processed file name: '{}'", processed);
             return processed;
         }
@@ -1007,14 +1009,21 @@ mod tests {
 
     #[test]
     fn test_get_processed_file_name_edge_cases() {
-        // No extension
+        // No extension — unchanged.
         assert_eq!(get_processed_file_name("noext"), "noext");
-        // Only extension
+        // Only extension (no stem) — unchanged.
         assert_eq!(get_processed_file_name(".txt"), ".txt");
-        // Multiple dots
+        // Multiple dots — unchanged (one extension stripped).
         assert_eq!(get_processed_file_name("a.b.txt"), "a.b");
-        // Path with directories
-        assert_eq!(get_processed_file_name("dir/file.md"), "file");
+        // Issue #70: parent directory is now PRESERVED when an
+        // extension is stripped, so per-locale subdirs like `fr/`
+        // survive into the output URL. Pre-#70 this returned just
+        // "file"; post-#70 it returns "dir/file".
+        assert_eq!(get_processed_file_name("dir/file.md"), "dir/file");
+        assert_eq!(
+            get_processed_file_name("fr/_posts/article.md"),
+            "fr/_posts/article"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- `render_page()` no longer aborts with `invalid template or partial name: ""` when frontmatter omits the `layout:` key — defaults to `page`.
- Adds `test_compile_defaults_layout_when_missing` to lock the behaviour.

## Background
Reported in #67. Surfaced on real-world sites (sebastienrousseau.github.io, ~1,137 of 2,371 files affected) and currently shimmed downstream in `sebastienrousseau/static-site-generator@v0.0.45` via `src/core/content_stager.rs::inject_default_layout_if_missing`. Once this lands and `staticdatagen 0.0.10` is released, the downstream shim is removed.

## Test plan
- [x] `cargo test --lib test_compile_defaults_layout_when_missing`
- [x] `cargo test --lib test_compile_success` (regression — pre-existing test must still pass)
- [ ] Full `cargo test` once CI runs